### PR TITLE
MiqUUID was replaced by SecureRandom

### DIFF
--- a/minishift/get_token.sh
+++ b/minishift/get_token.sh
@@ -11,6 +11,6 @@ cat <<EOT
 token = '$TOKEN'
 host  = '$IP'
 os = ManageIQ::Providers::Openshift::ContainerManager
-os.create(:name => "Minishift", :hostname => host, :port => 8443, :ipaddress => host, :guid => MiqUUID.new_guid, :zone => Zone.first, :storage_profiles => [], :security_protocol => "ssl-without-validation")
+os.create(:name => "Minishift", :hostname => host, :port => 8443, :ipaddress => host, :guid => SecureRandom.uuid, :zone => Zone.first, :storage_profiles => [], :security_protocol => "ssl-without-validation")
 os.last.update_authentication(:bearer => {:auth_key => token, :save => true})
 EOT


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-gems-pending/pull/151/commits/1911b8ac36f97a66e161009704fbf328e4961dd0 dropped `MiqUUID.new_guid` in favor of `SecureRandom.uuid`